### PR TITLE
remove matrix for workflows, as MySQL engine is now the default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,6 @@ jobs:
   smoke-test:
     name: Setup infrastructure
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # run test with the default, which is "mariadb", and the feature flag
-        # which will run mysql in a separate container
-        mysql-feature-flag: ["default (mariadb)", "mysql"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -45,17 +40,12 @@ jobs:
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
           LOCALSTACK_VOLUME_DIR: ${{ github.workspace }}/ls_test
-          MYSQL_FEATURE_FLAG: ${{ matrix.mysql-feature-flag }}
         run: |
           mkdir ls_test
           ls -la ls_test
           docker pull localstack/localstack-pro:latest
           # Start LocalStack in the background
-          if [ "mysql" ==  ${MYSQL_FEATURE_FLAG} ]; then
-            LS_LOG=trace RDS_MYSQL_DOCKER=1 localstack start -d
-          else
-            LS_LOG=trace localstack start -d
-          fi
+          LS_LOG=trace localstack start -d
           # Wait 30 seconds for the LocalStack container to become ready before timing out
           echo "Waiting for LocalStack startup..."
           localstack wait -t 15


### PR DESCRIPTION
Resolves https://github.com/localstack-samples/sample-cdk-rds/issues/6. 
Running two workflows is not required anymore, as MySQL engine is the default for LocalStack now.