### PR TITLE
Migrate to AWS_ENDPOINT_URL

### DIFF
--- a/demos/rds-init-fn-code/index.js
+++ b/demos/rds-init-fn-code/index.js
@@ -7,12 +7,14 @@ const fs = require('fs')
 const path = require('path')
 require('dotenv').config();
 
-// the env LOCALSTACK_HOSTNAME is automatically injected and available
-const hostname = process.env.LOCALSTACK_HOSTNAME;
+// the env AWS_ENDPOINT_URL is automatically injected and available
+const endpoint = process.env.AWS_ENDPOINT_URL;
+const url = new URL(endpoint);
+const hostname = url.hostname;
 
 // configure the secretsmanager to connect to the running LocalStack instance
 const secrets = new AWS.SecretsManager({ 
-  endpoint: 'http://' + hostname + ':4566',
+  endpoint: endpoint,
   accessKeyId: 'test',
   secretAccessKey: 'test',
   region: 'us-east-1',

--- a/demos/rds-query-fn-code/index.js
+++ b/demos/rds-query-fn-code/index.js
@@ -2,12 +2,14 @@ const mysql = require('mysql2')
 const AWS = require('aws-sdk')
 require('dotenv').config();
 
-// the env LOCALSTACK_HOSTNAME is automatically injected and available
-const hostname = process.env.LOCALSTACK_HOSTNAME;
+// the env AWS_ENDPOINT_URL is automatically injected and available
+const endpoint = process.env.AWS_ENDPOINT_URL;
+const url = new URL(endpoint);
+const hostname = url.hostname;
 
 // configure the secretsmanager to connect to the running LocalStack instance
 const secrets = new AWS.SecretsManager({ 
-  endpoint: 'http://' + hostname + ':4566',
+  endpoint: endpoint,
   accessKeyId: 'test',
   secretAccessKey: 'test',
   region: 'us-east-1',


### PR DESCRIPTION
Adopt `AWS_ENDPOINT_URL` as the official endpoint variable introduced by AWS.

See https://docs.localstack.cloud/user-guide/tools/transparent-endpoint-injection/

/cc repo maintainer @steffyP 

## Suggested Follow-Up

Why do we adopt the application code for LocalStack rather than injecting the configuration through IaC like in the original AWS example?
https://github.com/aws-samples/amazon-rds-init-cdk/blob/main/demos/rds-init-fn-code/index.js#L14

IMHO, It would be better to adopt clean IaC practices and separate code from configuration. Then we don't need to rely on LocalStack-only environment variables.

Similar case for https://github.com/localstack-samples/sample-serverless-rds-proxy-demo/pull/18

