### PR TITLE
Migrate from awslocal, cdklocal, and setup-localstack to lstk

### DIFF
--- a/.github/workflows/cloud-pods.yml
+++ b/.github/workflows/cloud-pods.yml
@@ -36,6 +36,10 @@ jobs:
         run: |
           npm install -g @localstack/lstk
 
+      - name: Install CDK
+        run: |
+          npm install -g aws-cdk
+
       - name: Start LocalStack
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}

--- a/.github/workflows/cloud-pods.yml
+++ b/.github/workflows/cloud-pods.yml
@@ -31,20 +31,17 @@ jobs:
         run: |
           make install
 
-      - name: Install CDK
+
+      - name: Install lstk
         run: |
-          npm install -g aws-cdk-local aws-cdk
-          cdklocal --version
+          npm install -g @localstack/lstk
 
       - name: Start LocalStack
-        uses: LocalStack/setup-localstack@main
-        with:
-          image-tag: 'latest'
-          use-pro: 'true'
-          configuration: LS_LOG=trace
-          install-awslocal: 'true'
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          LOCALSTACK_LS_LOG: trace
+        run: |
+          lstk start
 
       - name: Deploy the application
         env: 
@@ -58,13 +55,12 @@ jobs:
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
-          message="Cloud Pod created: sample-cdk-rds on $(date) with workflow run id: ${{ github.run_id }}"
-          localstack pod save sample-cdk-rds --message "$message"
+          lstk snapshot save pod:sample-cdk-rds
 
       - name: Show LocalStack Logs
         if: always()
         run: |
-          localstack logs
+          lstk logs
 
   test-cloud-pod:
     name: Test Cloud Pod
@@ -80,20 +76,22 @@ jobs:
           node-version: 22
           cache: 'npm'
 
+      - name: Install lstk
+        run: |
+          npm install -g @localstack/lstk
+
       - name: Start LocalStack
-        uses: LocalStack/setup-localstack@main
-        with:
-          use-pro: 'true'
-          install-awslocal: 'true'
         env:
-          DEBUG: 1
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          LOCALSTACK_DEBUG: 1
+        run: |
+          lstk start
 
       - name: Load Cloud Pod
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
-          localstack pod load sample-cdk-rds
+          lstk snapshot load pod:sample-cdk-rds
 
       - name: Install dependencies
         run: |
@@ -106,7 +104,7 @@ jobs:
       - name: Show LocalStack Logs
         if: always()
         run: |
-          localstack logs
+          lstk logs
 
       - name: Send a Slack notification
         if: failure() || github.event_name != 'pull_request'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,10 @@ jobs:
         run: |
           npm install -g @localstack/lstk
 
+      - name: Install CDK
+        run: |
+          npm install -g aws-cdk
+
       - name: Start LocalStack
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,20 +32,16 @@ jobs:
         run: |
           make install
 
-      - name: Install CDK
+      - name: Install lstk
         run: |
-          npm install -g aws-cdk-local aws-cdk
-          cdklocal --version
+          npm install -g @localstack/lstk
 
       - name: Start LocalStack
-        uses: LocalStack/setup-localstack@v0.2.4
-        with:
-          image-tag: 'latest'
-          use-pro: 'true'
-          configuration: LS_LOG=trace
-          install-awslocal: 'true'
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          LOCALSTACK_LS_LOG: trace
+        run: |
+          lstk start
 
       - name: Deploy the application
         env: 
@@ -62,7 +58,7 @@ jobs:
       - name: Show Logs
         if: always()
         run: |
-          localstack logs
+          lstk logs
 
       - name: Send a Slack notification
         if: failure() || github.event_name != 'pull_request'

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,9 @@ check:			## Check if all required prerequisites are installed
 	@command -v docker > /dev/null 2>&1 || { echo "Docker is not installed. Please install Docker and try again."; exit 1; }
 	@command -v node > /dev/null 2>&1 || { echo "Node.js is not installed. Please install Node.js and try again."; exit 1; }
 	@command -v aws > /dev/null 2>&1 || { echo "AWS CLI is not installed. Please install AWS CLI and try again."; exit 1; }
-	@command -v localstack > /dev/null 2>&1 || { echo "LocalStack is not installed. Please install LocalStack and try again."; exit 1; }
 	@command -v cdk > /dev/null 2>&1 || { echo "CDK is not installed. Please install CDK and try again."; exit 1; }
-	@command -v cdklocal > /dev/null 2>&1 || { echo "cdklocal is not installed. Please install cdklocal and try again."; exit 1; }
+	@command -v lstk > /dev/null 2>&1 || { echo "lstk is not installed. Please install lstk and try again."; exit 1; }
 	@command -v aws > /dev/null 2>&1 || { echo "AWS CLI is not installed. Please install AWS CLI and try again."; exit 1; }
-	@command -v awslocal > /dev/null 2>&1 || { echo "awslocal is not installed. Please install awslocal and try again."; exit 1; }
 	@echo "All required prerequisites are available."
 
 install:		## Install all required dependencies
@@ -32,9 +30,9 @@ install:		## Install all required dependencies
 
 deploy:			## Deploy the CDK stack
 		@echo "Bootstrapping CDK..."
-		cdklocal bootstrap
+		lstk cdk bootstrap
 		@echo "Deploying CDK..."
-		cdklocal deploy --require-approval never
+		lstk cdk deploy --require-approval never
 		@echo "CDK deployed successfully."
 
 test:			## Run the tests
@@ -47,35 +45,34 @@ run:			## Execute a SQL query through the Lambda function
 		@aws_version=$$(aws --version | grep -o "aws-cli/[0-9]*" | cut -d'/' -f2); \
 		if [ "$$aws_version" = "2" ]; then \
 			echo "Using AWS CLI version 2 command format..."; \
-			awslocal lambda invoke \
+			lstk aws lambda invoke \
 				--cli-binary-format raw-in-base64-out \
 				--function-name my-lambda-rds-query-helper \
 				--payload '{"sqlQuery": "select Author from books", "secretName":"/rdsinitexample/rds/creds/mysql-01"}' output; \
 		else \
 			echo "Using AWS CLI version 1 command format..."; \
-			awslocal lambda invoke \
+			lstk aws lambda invoke \
 				--function-name my-lambda-rds-query-helper \
 				--payload '{"sqlQuery": "select Author from books", "secretName":"/rdsinitexample/rds/creds/mysql-01"}' output; \
 		fi
 		@echo "Query execution completed. Results:"
 		@cat output
 
-start:			## Start LocalStack in detached mode
+start:			## Start LocalStack (blocks until ready)
 		@echo "Starting LocalStack..."
 		@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
-		@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+		@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) lstk start
 		@echo "LocalStack started successfully."
 
 stop:			## Stop LocalStack
 		@echo "Stopping LocalStack..."
-		@localstack stop
+		@lstk stop
 		@echo "LocalStack stopped successfully."
 
-ready:			## Wait for LocalStack to be ready
-		@echo Waiting on the LocalStack container...
-		@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+ready:			## Confirm LocalStack is ready (lstk start already waits, so this just reports status)
+		@lstk status
 
 logs:			## Get LocalStack logs
-		@localstack logs > logs.txt
+		@lstk logs > logs.txt
 
 .PHONY: usage check start ready install deploy test logs stop

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ The following diagram shows the architecture that this sample application builds
 ## Prerequisites
 
 - A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
-- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
-- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal).
-- [CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`cdklocal`](https://www.npmjs.com/package/aws-cdk-local) wrapper.
+- [`lstk` CLI](https://docs.localstack.cloud/aws/tooling/lstk/).
+- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`lstk aws` proxy](https://docs.localstack.cloud/aws/tooling/lstk/).
+- [CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`lstk cdk` proxy](https://docs.localstack.cloud/aws/tooling/lstk/).
 - [Node.js](https://nodejs.org/en/download/)
 - [`make`](https://www.gnu.org/software/make/) (**optional**, but recommended for running the sample application)
 
@@ -60,8 +60,7 @@ make install
 Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```shell
-localstack auth set-token <your-auth-token>
-localstack start
+lstk start
 ```
 > [!NOTE]
 > By default, LocalStack uses the MariaDB engine (see [RDS documentation](https://docs.localstack.cloud/user-guide/aws/rds/#mysql-engine)). 
@@ -104,7 +103,7 @@ This function requires two parameters:
 To run a query using AWS CLI version 1, you can invoke the Lambda function with the following command:
 
 ```shell
-awslocal lambda invoke \
+lstk aws lambda invoke \
   --function-name my-lambda-rds-query-helper \
   --payload '{"sqlQuery": "select Author from books", "secretName":"/rdsinitexample/rds/creds/mysql-01"}' output
 ```
@@ -112,7 +111,7 @@ awslocal lambda invoke \
 If you are using AWS CLI version 2, the command must include an additional flag for payload formatting:
 
 ```shell
-awslocal lambda invoke \
+lstk aws lambda invoke \
   --cli-binary-format raw-in-base64-out \
   --function-name my-lambda-rds-query-helper \
   --payload '{"sqlQuery": "select Author from books", "secretName":"/rdsinitexample/rds/creds/mysql-01"}' output

--- a/demos/rds-query-fn-code/index.js
+++ b/demos/rds-query-fn-code/index.js
@@ -19,7 +19,7 @@ const secrets = new SecretsManagerClient({
 
 // the function expects "secretName" and "sqlQuery" as payload
 // sample call using aws-cli:
-//     $ awslocal lambda invoke --function-name my-lambda-rds-query-helper --payload '{"sqlQuery": "select Author from books", "secretName":"/rdsinitexample/rds/creds/mysql-01"}' output
+//     $ lstk aws lambda invoke --function-name my-lambda-rds-query-helper --payload '{"sqlQuery": "select Author from books", "secretName":"/rdsinitexample/rds/creds/mysql-01"}' output
 // the result is in the 'output' file:
 //     $ cat output
 exports.handler = async (event, context) => {


### PR DESCRIPTION
## Summary
- Replace the standalone `localstack`/`awslocal`/`cdklocal` CLIs with the `lstk` CLI wherever they occur.
- Replace the `LocalStack/setup-localstack` GitHub Action with `lstk start` in both `main.yml` and `cloud-pods.yml`.

## Testing
- Tested by manually following the steps in the README
- Tested by manually invoking the GitHub Actions workflows
